### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains Python samples demonstrating how to generate images usi
 - Install dependencies:
   ```sh
   pip install openai python-dotenv gradio pillow
-
+  ```
 ## Known issues
 - There's a bug when downloading the file in the Gradio app - it always downloads as a .webp, despite what output format the user requests
 - C2PA Content Credentials don't work reliably right now


### PR DESCRIPTION
## Summary
- close the install command code block in README

## Testing
- `python -m py_compile generate-aoai.py generate-gradio.py`
